### PR TITLE
Add listener to the multicast address

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -84,21 +84,24 @@ var Browser = module.exports = function (serviceType) {
           if (address.indexOf(':') !== -1) {
             continue;
           }
-          createSocket(index++, key, address, bindToAddress.bind(self));
+          createSocket(index++, key, address, 0, bindToAddress.bind(self));
         }
       }
     }
+
+    createSocket(index++, key, "224.0.0.251", 5353, bindToAddress.bind(self));
   }.bind(this));
 
 
-  function createSocket (interfaceIndex, networkInterface, address, callback) {
+  function createSocket(interfaceIndex, networkInterface, address, port, callback) {
     var sock = dgram.createSocket('udp4');
     debug('creating socket for interface %s', address);
     created++;
-    sock.bind(0, address, function (err) {
+    sock.bind(port, address, function (err) {
       callback(err, interfaceIndex, networkInterface, sock);
     });
   }
+
 
 
   function bindToAddress (err, interfaceIndex, networkInterface, sock) {


### PR DESCRIPTION
It seems at least the latest update of the Apple TV OS only responds to mdns requests by sending a new broadcast to 224.0.0.251, no direct response is made to the originating device:

$ sudo tcpdump -n udp port 5353
22:44:19.870618 IP 10.0.1.5.56437 > 224.0.0.251.5353: 0 PTR (QM)? _airplay._tcp.local. (37)
22:44:20.250040 IP 10.0.1.3.5353 > 224.0.0.251.5353: 0_\- [0q] 1/0/4 PTR Apple TV._airplay._tcp.local. (309)
22:44:20.250650 IP6 fe80::c7a:22b5:cd2a:ae0e.5353 > ff02::fb.5353: 0_\- [0q] 1/0/4 PTR Apple TV._airplay._tcp.local. (309)
