### PR TITLE
Ammended the `asName` DNSRecord method

### DIFF
--- a/lib/dnsrecord.js
+++ b/lib/dnsrecord.js
@@ -65,6 +65,16 @@ DNSRecord.toName = function (name) {
 
 DNSRecord.prototype.asName = function () {
   debug('parse PTR');
+
+  // This addresses an issue with certain MDNS services (Airplay) that report
+  // their service type through the FQDN name as apposed to the data field.
+  if (typeof this.name === 'string') {
+    var splitName = this.name.split('.');
+    if (splitName.length === 3 && splitName[2] === 'local') {
+      return splitName.slice(0, 2).join('.');
+    }
+  }
+
   return new DataConsumer(this.data_).name();
 };
 


### PR DESCRIPTION
This change addresses an issue with certain MDNS services (Airplay) that report their service type through the FQDN name as apposed to the data field. This fixes the issue presented in #13 [comment 13](https://github.com/kmpm/node-mdns-js/pull/13#issuecomment-60866056).

From my [previous comment](https://github.com/kmpm/node-mdns-js/pull/13#issuecomment-61455471)

> The issue lies with the way the service type is obtained for the DNS record. The packet decoding code calls the asName method on the record which transforms the buffer in the data_ field of the packet into a string. The data_ field of the packet multicasted by the Apple TV contains the name of the Apple TV device itself (IE: John's Apple TV), not the service name as the decoder.js/dnsrecord.js code expects. The service name is instead in the name field (the FQDN) of the DNS record, albeit with ".local" appended to it.
