### PR TITLE
Working on https://github.com/kmpm/node-mdns-js/issues/18, 

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -101,7 +101,10 @@ var Browser = module.exports = function (serviceType) {
     var sock = dgram.createSocket('udp4');
     debug('creating socket for interface %s', address);
     created++;
-    sock.bind(port, address, function (err) {
+    sock.bind(port, function (err) {
+      if(port==5353){
+          sock.addMembership(address)
+      }
       cb(err, interfaceIndex, networkInterface, sock);
     });
   }


### PR DESCRIPTION
Windows doesn't allow to bind to non existing network addresses, multicast address has to be added with addMembership instead of a normal ip address.
