### PR TITLE
Fixed to correctly check INADDR_ANY parameter

### DIFF
--- a/lib/advertisement.js
+++ b/lib/advertisement.js
@@ -154,7 +154,7 @@ var Advertisement = module.exports = function (
   this.alias = '';
   this.status = 0; // inactive
   this.networking = networking;
-  if (typeof this.options.INADDR_ANY !== undefined) {
+  if (typeof this.options.INADDR_ANY !== 'undefined') {
     this.networking.INADDR_ANY = this.options.INADDR_ANY;
   }
 


### PR DESCRIPTION
The check for `INADDR_ANY` parameter while creating an `Advertisement` object always results in true, which sets `networking.INADDR_ANY` to false regardless of users' intent. This PR fixes the issue.
