### PR TITLE
Handling of packet parsing error

### DIFF
--- a/lib/networking.js
+++ b/lib/networking.js
@@ -136,6 +136,7 @@ Networking.prototype.bindToAddress = function (err, interfaceIndex, networkInter
     catch (er) {
       //partial, skip it
       debug('packet parsing error', er);
+      return;
     }
 
     self.emit('packets', packets, remote, connection);


### PR DESCRIPTION
mDNS crashes when a packet parsing error occurs. This PR fixes this by not triggering event after packet parsing error is detected.