### PR TITLE
Ensure it's possible to create a new Browser after closing a previous one.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,4 +1,3 @@
-
 var debug = require('debug')('mdns:browser');
 
 var util = require('util');
@@ -137,11 +136,14 @@ var Browser = module.exports = function (networking, serviceType) {
     self.emit('ready');
   });
 
+  var onMessageListener = internal.onMessage.bind(this);
+  
   this.stop = function () {
     networking.removeUsage(this);
+    networking.removeListener('packets', onMessageListener);
   };//--start
 
-  networking.on('packets', internal.onMessage.bind(this));
+  networking.on('packets', onMessageListener);
 
   this.discover = function () {
     var packet = new DNSPacket();

--- a/lib/networking.js
+++ b/lib/networking.js
@@ -65,6 +65,8 @@ Networking.prototype.stop = function () {
 
   this.connections.forEach(closeEach);
   this.connections = [];
+  this.created = 0;
+  this.started = false;
 
   function closeEach(connection) {
     var socket = connection.socket;


### PR DESCRIPTION
This fixes a bug that made it impossible to create a new `browser.js` object after closing the original `browser.js` object.

When closing the object using:

```
browser.removeAllListeners();
browser.stop();
```

Any new instance of the `browser.js` class would not have it's `update` event triggered. This is due to the original event listener not being cleaned up. The `networking.js` class also required a fix to properly reset the `counter` after all users called `removeUsage` or `stopRequest`.

Below is a code example that demonstrates the new fixes. Using this with the old code will result in an empty list of services after the first run.

**Is it possible to create a new release and publish this one to NPM?**

```
var mdns = require('../');

var services = [];

function create() {
  mdns.excludeInterface('0.0.0.0');
  var browser = mdns.createBrowser(mdns.tcp('workstation')); //defaults to mdns.ServiceType.wildcard

  browser.on('ready', function onReady() {
    browser.discover();
  });

  browser.on('update', function onUpdate(data) {
    services.push(data.fullname);
  });

  return browser;
}

function destroy(browser) {
  browser.removeAllListeners();
  browser.stop();
  services = [];
}

setInterval(function() {
  var browser = create();

  setTimeout(function() {
    console.log(services);

    destroy(browser);
  }, 1000);
}, 2000);
```
