### PR TITLE
Fix to stale state in networking connections when more than one user …

### DIFF
--- a/lib/networking.js
+++ b/lib/networking.js
@@ -215,5 +215,10 @@ Networking.prototype.removeUsage = function (browser) {
   if (index > -1) {
     this.users.splice(index, 1);
   }
+  // TODO should also clear stale state out of addresses table
+  this.connections.forEach(function (c) {
+    if (c.services && c.services[browser.serviceType.toString()])
+      delete c.services[browser.serviceType.toString()];
+  });
   this.stopRequest();
 };


### PR DESCRIPTION
…of the networking layer.

I have an application that is both advertising a service and browsing other services. When I detect a service connection failure (non mDNS methods), particularly due to a network connection failure, I need to restart the browser to make a new query and then receive an update. Because I cannot stop the networking due to maintaining my own advertisement, the `networking.connections` internal database still contains stale state from the previous running browser and does not produce an update event. 
