### PR TITLE
Initial IPv6 support 

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,15 @@ module.exports.setNetworkOptions = (options) => {
   networking.options = options;
 };
 
+/**
+ * Enables getting network options
+ * @method
+ * @return {object} options - A configuration object describing the desired network options
+ */
+module.exports.getNetworkOptions = () => {
+  return networking.options;
+};
+
 
 /* @borrows Advertisement as Advertisement */
 module.exports.Advertisement = require('./lib/advertisement'); //just for convenience
@@ -91,6 +100,9 @@ module.exports.ServiceType = st.ServiceType;
 
 /** @property {module:ServiceType.makeServiceType} */
 module.exports.makeServiceType = st.makeServiceType;
+
+/** @property */
+module.exports.networking = networking;
 
 /** @function */
 module.exports.tcp = st.protocolHelper('tcp');

--- a/index.js
+++ b/index.js
@@ -55,6 +55,11 @@ module.exports.listenOnLinkLocalMulticastOnly = () => {
   networking.INADDR_ANY = false;
 };
 
+/**
+ * Enables setting network options between initialization and starting
+ * @method
+ * @param {object} options - A configuration object describing the desired network options
+ */
 module.exports.setNetworkOptions = (options) => {
   if (networking.started) {
     throw new Error('can not set network options after interfaces have been started');

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports.excludeInterface = function (iface) {
   if (networking.started) {
     throw new Error('can not exclude interfaces after start');
   }
-  if (iface === '0.0.0.0') {
+  if (iface === '0.0.0.0' || iface === '::') {
     networking.INADDR_ANY = false;
   }
   else {

--- a/index.js
+++ b/index.js
@@ -56,6 +56,18 @@ module.exports.listenOnLinkLocalMulticastOnly = () => {
 };
 
 /**
+ * Enables setting the desired address family
+ * @method
+ * @param {string} family - String Enum, either 'IPv4', 'IPv6', 'both' or 'any'
+ */
+module.exports.setAddressFamily = (family) => {
+  if (['IPv4', 'IPv6', 'both', 'any'].indexOf(family) === -1) {
+    throw new Error('invalid network address family option: ' + family + ", must be either 'IPv4', 'IPv6', 'both' or 'any'");
+  }
+  networking.ADDR_FAMILY = family;
+};
+
+/**
  * Enables setting network options between initialization and starting
  * @method
  * @param {object} options - A configuration object describing the desired network options

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports.excludeInterface = function (iface) {
  * This is a convenience function to avoid having to manually exclude both address families.
  * @method
  */
-module.exports.listenOnLinkLocalMulticastOnly = () => {
+module.exports.listenOnLinkLocalMulticastOnly = function () {
   if (networking.started) {
     throw new Error('can not exclude interfaces after start');
   }
@@ -60,7 +60,7 @@ module.exports.listenOnLinkLocalMulticastOnly = () => {
  * @method
  * @param {string} family - String Enum, either 'IPv4', 'IPv6', 'both' or 'any'
  */
-module.exports.setAddressFamily = (family) => {
+module.exports.setAddressFamily = function (family) {
   if (['IPv4', 'IPv6', 'both', 'any'].indexOf(family) === -1) {
     throw new Error('invalid network address family option: ' + family + ", must be either 'IPv4', 'IPv6', 'both' or 'any'");
   }
@@ -72,7 +72,7 @@ module.exports.setAddressFamily = (family) => {
  * @method
  * @param {object} options - A configuration object describing the desired network options
  */
-module.exports.setNetworkOptions = (options) => {
+module.exports.setNetworkOptions = function (options) {
   if (networking.started) {
     throw new Error('can not set network options after interfaces have been started');
   }
@@ -84,7 +84,7 @@ module.exports.setNetworkOptions = (options) => {
  * @method
  * @return {object} options - A configuration object describing the desired network options
  */
-module.exports.getNetworkOptions = () => {
+module.exports.getNetworkOptions = function () {
   return networking.options;
 };
 

--- a/index.js
+++ b/index.js
@@ -40,6 +40,13 @@ module.exports.excludeInterface = function (iface) {
   }
 };
 
+module.exports.setNetworkOptions = (options) => {
+  if (networking.started) {
+    throw new Error('can not set network options after interfaces have been started');
+  }
+  networking.options = options;
+};
+
 
 /* @borrows Advertisement as Advertisement */
 module.exports.Advertisement = require('./lib/advertisement'); //just for convenience

--- a/index.js
+++ b/index.js
@@ -40,6 +40,21 @@ module.exports.excludeInterface = function (iface) {
   }
 };
 
+/**
+ * Restrict the network socket to only listen on the respective link local multicast addresses
+ * IPv4: 224.0.0.251
+ * IPv6: FF02::FB
+ * instead of binding the port to all receiving local IP addresses (0.0.0.0 / ::).
+ * This is a convenience function to avoid having to manually exclude both address families.
+ * @method
+ */
+module.exports.listenOnLinkLocalMulticastOnly = () => {
+  if (networking.started) {
+    throw new Error('can not exclude interfaces after start');
+  }
+  networking.INADDR_ANY = false;
+};
+
 module.exports.setNetworkOptions = (options) => {
   if (networking.started) {
     throw new Error('can not set network options after interfaces have been started');

--- a/lib/networking.js
+++ b/lib/networking.js
@@ -10,214 +10,226 @@ var semver = require('semver');
 
 var dns = require('dns-js');
 var DNSPacket = dns.DNSPacket;
-//var DNSRecord = dns.DNSRecord;
 
-var MDNS_MULTICAST = '224.0.0.251';
+var MDNS_MULTICAST_IPV4 = '224.0.0.251';
+var MDNS_MULTICAST_IPV6 = 'FF02::FB';
 
-
-var Networking = module.exports = function (options) {
-  this.options = options || {};
-  this.created = 0;
-  this.connections = [];
-  this.started = false;
-  this.users = [];
-  this.INADDR_ANY = typeof this.options.INADDR_ANY === 'undefined' ?
-    true : this.options.INADDR_ANY;
+var Networking = module.exports = function(options) {
+    this.options = options || {};
+    this.created = 0;
+    this.connections = [];
+    this.started = false;
+    this.users = [];
+    this.INADDR_ANY = typeof this.options.INADDR_ANY === 'undefined' ? true : this.options.INADDR_ANY;
+    this.ADDR_FAMILY = typeof this.options.ADDR_FAMILY === 'undefined' ? 'IPv4' : this.options.ADDR_FAMILY;
 };
 
 util.inherits(Networking, EventEmitter);
 
+Networking.prototype.start = function() {
+    var interfaces = os.networkInterfaces();
+    var ifaceFilter = this.options.networkInterface;
+    var index = 0;
+    for (var key in interfaces) {
+        if ((interfaces.hasOwnProperty(key)) &&
+            ((typeof ifaceFilter === 'undefined') || (key === ifaceFilter))) {
+            for (var i = 0; i < interfaces[key].length; i++) {
+                var iface = interfaces[key][i];
+                //no localhost
+                if (iface.internal) {
+                    continue;
+                }
 
-Networking.prototype.start = function () {
-  var interfaces = os.networkInterfaces();
-  var ifaceFilter = this.options.networkInterface;
-  var index = 0;
-  for (var key in interfaces) {
-    if ((interfaces.hasOwnProperty(key)) &&
-      ((typeof ifaceFilter === 'undefined') || (key === ifaceFilter))) {
-      for (var i = 0; i < interfaces[key].length; i++) {
-        var iface = interfaces[key][i];
-        //no localhost
-        if (iface.internal) {
-          continue;
+                // Skip address family IPv4 when using IPv6
+                if (this.ADDR_FAMILY === 'IPv6' && iface.family === 'IPv4') {
+                    continue;
+                }
+                // Skip address family IPv6 when using IPv4
+                if (this.ADDR_FAMILY === 'IPv4' && iface.family === 'IPv6') {
+                    continue;
+                }
+
+                debug('interface', key, iface.address);
+                this.createSocket(index++, key,
+                    iface.address, 0, iface.family, this.bindToAddress.bind(this));
+            }
         }
-        //no IPv6 addresses
-        if (iface.address.indexOf(':') !== -1) {
-          continue;
+    }
+    // apple-tv always replies back using multicast,
+    // regardless of the source of the query, it is answering back
+    if (this.INADDR_ANY) {
+        this.createSocket(index++, 'IPv4 pseudo multicast', '0.0.0.0', 5353, 'IPv4', this.bindToAddress.bind(this));
+        this.createSocket(index++, 'IPv6 pseudo multicast', '::', 5353, 'IPv6', this.bindToAddress.bind(this));
+    }
+};
+
+
+Networking.prototype.stop = function() {
+    debug('stopping');
+
+    this.connections.forEach(closeEach);
+    this.connections = [];
+
+    function closeEach(connection) {
+        var socket = connection.socket;
+        socket.close();
+        socket.unref();
+    }
+};
+
+
+Networking.prototype.createSocket = function(
+    interfaceIndex, networkInterface, address, port, family, next) {
+    var sock;
+    var type = 'udp' + family.slice(-1);
+    if (semver.gte(process.versions.node, '0.11.13')) {
+        sock = dgram.createSocket({ type: type, reuseAddr: true });
+    }
+    else {
+        sock = dgram.createSocket(type);
+    }
+    sock.on('error', function(err) {
+        next(err, interfaceIndex, networkInterface, sock);
+    });
+    debug('creating socket for', networkInterface);
+    this.created++;
+
+
+    sock.bind(port, address, function(err) {
+        if ((!err) && (port === 5353)) {
+            if (address.indexOf('.') !== -1) {
+                sock.addMembership(MDNS_MULTICAST_IPV4);
+            } else {
+                sock.addMembership(MDNS_MULTICAST_IPV6);
+            }
+            sock.setMulticastTTL(255);
+            sock.setMulticastLoopback(true);
         }
-        debug('interface', key, iface.address);
-        this.createSocket(index++, key,
-          iface.address, 0, this.bindToAddress.bind(this));
-      }
-    }
-  }
-  // apple-tv always replies back using multicast,
-  // regardless of the source of the query, it is answering back.
-  if (this.INADDR_ANY) {
-    this.createSocket(index++, 'pseudo multicast',
-      '0.0.0.0', 5353, this.bindToAddress.bind(this));
-  }
-};
-
-
-Networking.prototype.stop = function () {
-  debug('stopping');
-
-  this.connections.forEach(closeEach);
-  this.connections = [];
-
-  function closeEach(connection) {
-    var socket = connection.socket;
-    socket.close();
-    socket.unref();
-  }
-};
-
-
-Networking.prototype.createSocket = function (
-  interfaceIndex, networkInterface, address, port, next) {
-  var sock;
-  if (semver.gte(process.versions.node, '0.11.13')) {
-    sock = dgram.createSocket({ type: 'udp4', reuseAddr: true });
-  }
-  else {
-    sock = dgram.createSocket('udp4');
-  }
-  sock.on('error', function (err) {
-    next(err, interfaceIndex, networkInterface, sock);
-  });
-  debug('creating socket for', networkInterface);
-  this.created++;
-
-
-  sock.bind(port, address, function (err) {
-    if ((!err) && (port === 5353)) {
-      sock.addMembership(MDNS_MULTICAST);
-      sock.setMulticastTTL(255);
-      sock.setMulticastLoopback(true);
-    }
-    next(err, interfaceIndex, networkInterface, sock);
-  });
+        next(err, interfaceIndex, networkInterface, sock);
+    });
 
 };
 
 
-Networking.prototype.bindToAddress = function (err, interfaceIndex, networkInterface, sock) {
-  if (err) {
-    debug('there was an error binding %s', err);
-    return;
-  }
-  debug('bindToAddress', networkInterface);
-  var info = sock.address();
-
-  var connection = {
-    socket: sock,
-    interfaceIndex: interfaceIndex,
-    networkInterface: networkInterface,
-    counters: {
-      sent: 0,
-      received: 0
+Networking.prototype.bindToAddress = function(err, interfaceIndex, networkInterface, sock) {
+    if (err) {
+        debug('there was an error binding %s', err);
+        return;
     }
-  };
+    debug('bindToAddress', networkInterface);
+    var info = sock.address();
 
-  this.connections.push(connection);
-  var self = this;
+    var connection = {
+        socket: sock,
+        interfaceIndex: interfaceIndex,
+        networkInterface: networkInterface,
+        counters: {
+            sent: 0,
+            received: 0
+        }
+    };
 
-  sock.on('message', function (message, remote) {
-    var packets;
-    connection.counters.received++;
-    debuginbound('incoming message', message.toString('hex'));
-    try {
-      packets = dns.DNSPacket.parse(message);
-      if (!(packets instanceof Array)) {
-        packets = [packets];
-      }
+    this.connections.push(connection);
+    var self = this;
+
+    sock.on('message', function(message, remote) {
+        var packets;
+        connection.counters.received++;
+        debuginbound('incoming message', message.toString('hex'));
+        try {
+            packets = dns.DNSPacket.parse(message);
+            if (!(packets instanceof Array)) {
+                packets = [packets];
+            }
+        }
+        catch (er) {
+            //partial, skip it
+            debug('packet parsing error', er);
+            return;
+        }
+
+        self.emit('packets', packets, remote, connection);
+    });
+
+    sock.on('error', self.onError.bind(self));
+
+    sock.on('close', function() {
+        debug('socket closed', info);
+    });
+
+
+    if (this.created === this.connections.length) {
+        this.emit('ready', this.connections.length);
     }
-    catch (er) {
-      //partial, skip it
-      debug('packet parsing error', er);
-      return;
-    }
-
-    self.emit('packets', packets, remote, connection);
-  });
-
-  sock.on('error', self.onError.bind(self));
-
-  sock.on('close', function () {
-    debug('socket closed', info);
-  });
-
-
-  if (this.created === this.connections.length) {
-    this.emit('ready', this.connections.length);
-  }
 };//--bindToAddress
 
 
-Networking.prototype.onError = function (err) {
-  this.emit('error', err);
+Networking.prototype.onError = function(err) {
+    this.emit('error', err);
 };
 
 
-Networking.prototype.send = function (packet) {
-  var buf = DNSPacket.toBuffer(packet);
-  this.connections.forEach(onEach);
-  debug('created buffer with length', buf.length);
-  debugoutbound('message', buf.toString('hex'));
-  function onEach(connection) {
-    var sock = connection.socket;
-    // if the user did not specially asked for the pseudo interface
-    // skip sending message on that interface.
-    if (sock.address().address === '0.0.0.0' && !this.INADDR_ANY) {
-      debug('skip send on pseudo interface.');
+Networking.prototype.send = function(packet) {
+    var buf = DNSPacket.toBuffer(packet);
+    this.connections.forEach(onEach);
+    debug('created buffer with length', buf.length);
+    debugoutbound('message', buf.toString('hex'));
+    function onEach(connection) {
+        var sock = connection.socket;
+        // if the user did not specially asked for the pseudo interface
+        // skip sending message on that interface.
+        // TODO Pseudo interface implementation restricted to IPv4
+        if ((sock.address().address === '0.0.0.0' && !this.INADDR_ANY) || this.ADDR_FAMILY === 'IPv6') {
+            debug('skip send on pseudo interface.');
+        }
+        else {
+            debug('sending to', sock.address());
+
+            var family = sock.type === 'udp4' ? MDNS_MULTICAST_IPV4 : MDNS_MULTICAST_IPV6
+
+            sock.send(buf, 0, buf.length, 5353, family, function(err, bytes) {
+                connection.counters.sent++;
+                debug('%s sent %d bytes with err:%s', sock.address().address, bytes,
+                    err);
+            });
+        }
     }
-    else {
-      debug('sending to', sock.address());
+};
 
-      sock.send(buf, 0, buf.length, 5353, '224.0.0.251', function (err, bytes) {
-        connection.counters.sent++;
-        debug('%s sent %d bytes with err:%s', sock.address().address, bytes,
-          err);
-      });
+Networking.prototype.startRequest = function(callback) {
+    if (this.started) {
+        return process.nextTick(callback());
     }
-  }
+    this.start();
+    this.once('ready', function() {
+        if (typeof callback === 'function') {
+            callback();
+        }
+    });
 };
 
-Networking.prototype.startRequest = function (callback) {
-  if (this.started) {
-    return process.nextTick(callback());
-  }
-  this.start();
-  this.once('ready', function () {
-    if (typeof callback === 'function') {
-      callback();
+
+Networking.prototype.stopRequest = function() {
+    if (this.users.length === 0) {
+        this.stop();
     }
-  });
 };
 
 
-Networking.prototype.stopRequest = function () {
-  if (this.users.length === 0) {
-    this.stop();
-  }
+Networking.prototype.addUsage = function(browser, next) {
+    this.users.push(browser);
+    this.startRequest(next);
 };
 
 
-Networking.prototype.addUsage = function (browser, next) {
-  this.users.push(browser);
-  this.startRequest(next);
-};
-
-
-Networking.prototype.removeUsage = function (browser) {
-  var index = this.users.indexOf(browser);
-  if (index > -1) {
-    this.users.splice(index, 1);
-  }
-  this.connections.forEach(function (c) {
-    if (c.services && c.services[browser.serviceType.toString()])
-      delete c.services[browser.serviceType.toString()];
-  });
-  this.stopRequest();
+Networking.prototype.removeUsage = function(browser) {
+    var index = this.users.indexOf(browser);
+    if (index > -1) {
+        this.users.splice(index, 1);
+    }
+    this.connections.forEach(function(c) {
+        if (c.services && c.services[browser.serviceType.toString()])
+            delete c.services[browser.serviceType.toString()];
+    });
+    this.stopRequest();
 };

--- a/lib/networking.js
+++ b/lib/networking.js
@@ -34,7 +34,7 @@ Networking.prototype.start = function () {
   var index = 0;
   for (var key in interfaces) {
     if ((interfaces.hasOwnProperty(key)) &&
-          ((typeof ifaceFilter === 'undefined') || (key === ifaceFilter))) {
+      ((typeof ifaceFilter === 'undefined') || (key === ifaceFilter))) {
       for (var i = 0; i < interfaces[key].length; i++) {
         var iface = interfaces[key][i];
         //no localhost
@@ -78,7 +78,7 @@ Networking.prototype.createSocket = function (
   interfaceIndex, networkInterface, address, port, next) {
   var sock;
   if (semver.gte(process.versions.node, '0.11.13')) {
-    sock = dgram.createSocket({type:'udp4', reuseAddr:true});
+    sock = dgram.createSocket({ type: 'udp4', reuseAddr: true });
   }
   else {
     sock = dgram.createSocket('udp4');
@@ -111,7 +111,7 @@ Networking.prototype.bindToAddress = function (err, interfaceIndex, networkInter
   var info = sock.address();
 
   var connection = {
-    socket:sock,
+    socket: sock,
     interfaceIndex: interfaceIndex,
     networkInterface: networkInterface,
     counters: {
@@ -178,7 +178,7 @@ Networking.prototype.send = function (packet) {
       sock.send(buf, 0, buf.length, 5353, '224.0.0.251', function (err, bytes) {
         connection.counters.sent++;
         debug('%s sent %d bytes with err:%s', sock.address().address, bytes,
-            err);
+          err);
       });
     }
   }
@@ -215,5 +215,9 @@ Networking.prototype.removeUsage = function (browser) {
   if (index > -1) {
     this.users.splice(index, 1);
   }
+  this.connections.forEach(function (c) {
+    if (c.services && c.services[browser.serviceType.toString()])
+      delete c.services[browser.serviceType.toString()];
+  });
   this.stopRequest();
 };

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "semver": "~5.1.0"
   },
   "devDependencies": {
-    "code": "*",
+    "code": "^4.0.0",
     "joi": "~7.1.0",
-    "lab": "*"
+    "lab": "^11.2.1"
   },
   "scripts": {
-    "test": "lab --flat --coverage",
+    "test": "lab --flat",
     "lint": "eslint test examples lib index.js",
     "doc": "jsdoc -d .\\doc index.js lib"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdns-js",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/mdns-js/node-mdns-js.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdns-js",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/mdns-js/node-mdns-js.git"

--- a/test/advertisement.test.js
+++ b/test/advertisement.test.js
@@ -60,5 +60,39 @@ describe('packetfactory', function () {
     expect(service.options, 'options').to.include({name: 'hello'});
 
     done();
+
   });
+
+  it('should enable setting networking options', function (done) {
+    var service = mdns.createAdvertisement(mdns.tcp('_http'), 9876, {
+      name: 'hello',
+      txt: {
+        txtvers: '1'
+      }
+    });
+
+    expect(mdns.getNetworkOptions()).to.be.empty();
+    mdns.setNetworkOptions({ test: 'test' });
+    expect(mdns.getNetworkOptions()).to.include('test');
+    mdns.setNetworkOptions({});
+    expect(mdns.getNetworkOptions()).to.be.empty();
+
+    done();
+  });
+
+  it('should enable restricting to linkLocal only addresses', function (done) {
+    var service = mdns.createAdvertisement(mdns.tcp('_http'), 9876, {
+      name: 'hello',
+      txt: {
+        txtvers: '1'
+      }
+    });
+
+    expect(mdns.networking.INADDR_ANY).to.equal(true);
+    mdns.listenOnLinkLocalMulticastOnly();
+    expect(mdns.networking.INADDR_ANY).to.equal(false);
+
+    done();
+  });
+
 });

--- a/test/advertisement.test.js
+++ b/test/advertisement.test.js
@@ -48,16 +48,16 @@ describe('packetfactory', function () {
 
   it('createAdvertisement', function (done) {
     var service = mdns.createAdvertisement(mdns.tcp('_http'), 9876, {
-      name:'hello',
-      txt:{
-        txtvers:'1'
+      name: 'hello',
+      txt: {
+        txtvers: '1'
       }
     });
 
-    expect(service).to.include({port:9876});
-    expect(service.serviceType).to.include({name: 'http', protocol: 'tcp'});
+    expect(service).to.include({ port: 9876 });
+    expect(service.serviceType).to.include({ name: 'http', protocol: 'tcp' });
     expect(service).to.include('options');
-    expect(service.options, 'options').to.include({name: 'hello'});
+    expect(service.options, 'options').to.include({ name: 'hello' });
 
     done();
 
@@ -91,6 +91,25 @@ describe('packetfactory', function () {
     expect(mdns.networking.INADDR_ANY).to.equal(true);
     mdns.listenOnLinkLocalMulticastOnly();
     expect(mdns.networking.INADDR_ANY).to.equal(false);
+
+    done();
+  });
+
+  it('should work be able to set address family', function (done) {
+    var service = mdns.createAdvertisement(mdns.tcp('_http'), 9876, {
+      name: 'hello',
+      txt: {
+        txtvers: '1'
+      }
+    });
+
+    expect(mdns.networking.ADDR_FAMILY).to.equal('IPv4');
+    mdns.setAddressFamily('IPv6');
+    expect(mdns.networking.ADDR_FAMILY).to.equal('IPv6');
+    mdns.setAddressFamily('both');
+    expect(mdns.networking.ADDR_FAMILY).to.equal('both');
+    mdns.setAddressFamily('any');
+    expect(mdns.networking.ADDR_FAMILY).to.equal('any');
 
     done();
   });

--- a/test/service_type_test.js
+++ b/test/service_type_test.js
@@ -13,7 +13,7 @@ var ServiceType = require('../lib/service_type').ServiceType;
 describe('ServiceType', function () {
   it('should parse _http._tcp', function (done) {
     var type = new ServiceType('_http._tcp');
-    expect(type).to.include({protocol: 'tcp', name: 'http'});
+    expect(type).to.include({ protocol: 'tcp', name: 'http' });
     expect(type.subtypes).to.be.empty();
     expect(type.isWildcard()).to.be.false();
     var a = type.toArray();
@@ -23,49 +23,49 @@ describe('ServiceType', function () {
 
   it('should parse service._http._tcp', function (done) {
     var type = new ServiceType('service._http._tcp');
-    expect(type).to.include({protocol: 'tcp', name: 'http'});
+    expect(type).to.include({ protocol: 'tcp', name: 'http' });
     expect(type.subtypes).to.be.empty();
     done();
   });
 
   it('should parse service._http._tcp.local', function (done) {
     var type = new ServiceType('service._http._tcp.local');
-    expect(type).to.include({protocol: 'tcp', name: 'http'});
+    expect(type).to.include({ protocol: 'tcp', name: 'http' });
     expect(type.subtypes).to.be.empty();
     done();
   });
 
   it('should parse _services._dns-sd._udp', function (done) {
     var type = new ServiceType('_services._dns-sd._udp');
-    expect(type).to.include({protocol: 'udp', name: 'services._dns-sd'});
+    expect(type).to.include({ protocol: 'udp', name: 'services._dns-sd' });
     expect(type.subtypes).to.be.empty();
     done();
   });
 
   it('should tak array as input', function (done) {
     var type = new ServiceType(['_http', '_tcp']);
-    expect(type).to.include({protocol: 'tcp', name: 'http'});
+    expect(type).to.include({ protocol: 'tcp', name: 'http' });
     expect(type.subtypes).to.be.empty();
     done();
   });
 
   it('should take multiple arguments is input', function (done) {
     var type = new ServiceType('_http', '_tcp');
-    expect(type).to.include({protocol: 'tcp', name: 'http'});
+    expect(type).to.include({ protocol: 'tcp', name: 'http' });
     expect(type.subtypes).to.be.empty();
     done();
   });
 
   it('should on empty arguments', function (done) {
     var type = new ServiceType();
-    expect(type).to.include({protocol: '', name: ''});
+    expect(type).to.include({ protocol: '', name: '' });
     expect(type.subtypes).to.be.empty();
     done();
   });
 
   it('should take object as argument', function (done) {
-    var type = new ServiceType({protocol: 'tcp', name: 'http'});
-    expect(type).to.include({protocol: 'tcp', name: 'http'});
+    var type = new ServiceType({ protocol: 'tcp', name: 'http' });
+    expect(type).to.include({ protocol: 'tcp', name: 'http' });
     expect(type.subtypes).to.be.empty();
     done();
   });
@@ -74,10 +74,10 @@ describe('ServiceType', function () {
     var type = new ServiceType({
       protocol: 'tcp',
       name: 'http',
-      subtypes:['printer']
+      subtypes: ['printer']
     });
-    expect(type).to.include({protocol: 'tcp', name: 'http'});
-    expect(type.subtypes).to.deep.equal(['printer']);
+    expect(type).to.include({ protocol: 'tcp', name: 'http' });
+    expect(type.subtypes).to.equal(['printer']);
     done();
   });
 
@@ -102,7 +102,7 @@ describe('ServiceType', function () {
 
   it('should default to _tcp', function (done) {
     var type = new ServiceType(['_http']);
-    expect(type).to.include({protocol: 'tcp', name: 'http'});
+    expect(type).to.include({ protocol: 'tcp', name: 'http' });
     expect(type.subtypes).to.be.empty();
     done();
   });
@@ -128,7 +128,7 @@ describe('ServiceType', function () {
 
   it('should throw on missing object name', function (done) {
     function fn() {
-      new ServiceType({protocol:'tcp'});
+      new ServiceType({ protocol: 'tcp' });
     }
     expect(fn).to.throw(Error,
       'required property name is missing');
@@ -137,7 +137,7 @@ describe('ServiceType', function () {
 
   it('should throw on missing object protocol', function (done) {
     function fn() {
-      new ServiceType({name: 'http'});
+      new ServiceType({ name: 'http' });
     }
     expect(fn).to.throw(Error,
       'required property protocol is missing');


### PR DESCRIPTION
This is a proposal pull-request creating initial support for IPv6 and respective settings. 

Address families can be selected via the following API extension:

        mdns.setAddressFamily(family);

where family is required to be a member of the string enum 'IPv4', 'IPv6', 'both', 'any'.

Additionally, binding to INADDR_ANY can now be disabled on all interfaces via

        mdns.listenOnLinkLocalMulticastOnly();

Both settings have to be set before the interfaces have been started.

I've also included some basic tests, but these are currently restricted to testings the proper function of the new API elements, not the actual process of using IPv6.

I'd love to receive feedback and am willing to improve this PR wherever it is deemed necessary.