### PR TITLE
Fix to allow having multiple browsers simultanously

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,114 +1,11 @@
-var debug = require('debug')('mdns:browser');
+const debug = require('debug')('mdns:browser');
 
-var util = require('util');
-var EventEmitter = require('events').EventEmitter;
+const util = require('util');
+const { EventEmitter } = require('events');
 
-
-var dns = require('dns-js');
-var DNSPacket = dns.DNSPacket;
-var DNSRecord = dns.DNSRecord;
-var ServiceType = require('./service_type').ServiceType;
-var decoder = require('./decoder');
-// var counter = 0;
-var internal = {};
-
-/**
- * Handles incoming UDP traffic.
- * @private
- */
-internal.onMessage = function (packets, remote, connection) {
-  debug('got packets from remote', remote);
-
-  var data = decoder.decodePackets(packets);
-  if (!data) {
-    return;
-  }
-  var isNew = false;
-
-  function setNew(/*msg*/) {
-    isNew = true;
-    debug('new on %s, because %s',
-      connection.networkInterface, util.format.apply(null, arguments));
-  }
-
-  function updateValue(src, dst, name) {
-    if (JSON.stringify(dst[name]) !== JSON.stringify(src)) {
-      setNew('updated host.%s', name);
-      dst[name] = src;
-    }
-  }
-
-  function addValue(src, dst, name) {
-    if (typeof dst[name] === 'undefined') {
-      setNew('added host.%s', name);
-      dst[name] = src;
-    }
-  }
-
-  if (data) {
-
-    data.interfaceIndex = connection.interfaceIndex;
-    data.networkInterface = connection.networkInterface;
-    data.addresses.push(remote.address);
-    if (!connection.services) {
-      connection.services = {};
-    }
-
-    if (!connection.addresses) {
-      connection.addresses = {};
-    }
-
-
-    if (typeof data.type !== 'undefined') {
-      data.type.forEach(function (type) {
-        var service;
-        var serviceKey = type.toString();
-        if (!connection.services.hasOwnProperty(serviceKey)) {
-          setNew('new service - %s', serviceKey);
-          service = connection.services[serviceKey] = {
-            type: type, addresses: []
-          };
-        }
-        else {
-          service = connection.services[serviceKey];
-        }
-
-        data.addresses.forEach(function (adr) {
-          if (service.addresses.indexOf(adr) === -1) {
-            service.addresses.push(adr);
-            setNew('new address');
-          }
-
-          var host;
-          if (connection.addresses.hasOwnProperty(adr)) {
-            host = connection.addresses[adr];
-          }
-          else {
-            host = connection.addresses[adr] = {address: adr};
-            setNew('new host');
-          }
-          addValue({}, host, serviceKey);
-          updateValue(data.port, host[serviceKey], 'port');
-          updateValue(data.host, host[serviceKey], 'host');
-          updateValue(data.txt, host[serviceKey], 'txt');
-        });
-      });
-    }
-
-
-    /**
-     * Update event
-     * @event Browser#update
-     * @type {object}
-     * @property {string} networkInterface - name of network interface
-     * @property {number} interfaceIndex
-     */
-    debug('isNew', isNew);
-    if (isNew && data) {
-      this.emit('update', data);
-    }
-  }
-};
+const { DNSPacket, DNSRecord } = require('dns-js');
+const { ServiceType } = require('./service_type');
+const decoder = require('./decoder');
 
 /**
  * mDNS Browser class
@@ -116,45 +13,136 @@ internal.onMessage = function (packets, remote, connection) {
  * @param {string|ServiceType} serviceType - The service type to browse for.
  * @fires Browser#update
  */
-var Browser = module.exports = function (networking, serviceType) {
-  if (!(this instanceof Browser)) { return new Browser(serviceType); }
+class Browser extends EventEmitter {
+  constructor (networking, serviceType) {
+    super();
+    const notString = typeof serviceType !== 'string';
+    const notType = !(serviceType instanceof ServiceType);
+    if (notString && notType) {
+      debug('serviceType type:', typeof serviceType);
+      debug('serviceType is ServiceType:', serviceType instanceof ServiceType);
+      debug('serviceType=', serviceType);
+      throw new Error('argument must be instance of ServiceType or valid string');
+    }
+    this.serviceType = serviceType;
+    this.networking = networking;
 
-  var notString = typeof serviceType !== 'string';
-  var notType = !(serviceType instanceof ServiceType);
-  if (notString && notType) {
-    debug('serviceType type:', typeof serviceType);
-    debug('serviceType is ServiceType:', serviceType instanceof ServiceType);
-    debug('serviceType=', serviceType);
-    throw new Error('argument must be instance of ServiceType or valid string');
+    this.connections = {};
+
+    networking.addUsage(this, () => {
+      this.emit('ready');
+    })
+
+    this.onMessageListener = this.onMessage.bind(this);
+    networking.on('packets', this.onMessageListener);
   }
-  this.serviceType = serviceType;
-  var self = this;
-  // var services = {};
-  // var addresses = {};
 
-  networking.addUsage(this, function () {
-    self.emit('ready');
-  });
+  /**
+ * Handles incoming UDP traffic.
+ * @private
+ */
+  onMessage (packets, remote, connection) {
+    debug('got packets from remote', remote);
 
-  var onMessageListener = internal.onMessage.bind(this);
+    const data = decoder.decodePackets(packets);
+    if (!data) {
+      return;
+    }
+    let isNew = false;
 
-  this.stop = function () {
-    networking.removeUsage(this);
-    networking.removeListener('packets', onMessageListener);
-  };//--start
+    const iface = connection.networkInterface;
+    this.connections[iface] = this.connections[iface] || {
+        services: {},
+        addresses: {}
+      };
+    const { services, addresses } = this.connections[iface];
 
-  networking.on('packets', onMessageListener);
+    function setNew (...args) {
+      isNew = true;
+      debug('new on %s, because %s', iface, util.format(...args));
+    }
 
-  this.discover = function () {
-    var packet = new DNSPacket();
+    function updateValue (src, dst, name) {
+      if (JSON.stringify(dst[name]) !== JSON.stringify(src)) {
+        setNew('updated host.%s', name);
+        dst[name] = src;
+      }
+    }
+
+    function addValue (src, dst, name) {
+      if (typeof dst[name] === 'undefined') {
+        setNew('added host.%s', name);
+        dst[name] = src;
+      }
+    }
+
+    if (data) {
+      data.interfaceIndex = connection.interfaceIndex;
+      data.networkInterface = connection.networkInterface;
+      data.addresses.push(remote.address);
+
+      if (typeof data.type !== 'undefined') {
+        data.type.forEach(function (type) {
+
+          let serviceKey = type.toString();
+          if (!services.hasOwnProperty(serviceKey)) {
+            setNew('new service - %s', serviceKey);
+            services[serviceKey] = {
+              type,
+              addresses: []
+            };
+          }
+
+          const service = services[serviceKey];
+          data.addresses.forEach(function (adr) {
+            if (service.addresses.indexOf(adr) === -1) {
+              service.addresses.push(adr);
+              setNew('new address');
+            }
+
+            let host;
+            if (addresses.hasOwnProperty(adr)) {
+              host = addresses[adr];
+            }else {
+              host = addresses[adr] = {address: adr};
+              setNew('new host');
+            }
+            addValue({}, host, serviceKey);
+            updateValue(data.port, host[serviceKey], 'port');
+            updateValue(data.host, host[serviceKey], 'host');
+            updateValue(data.txt, host[serviceKey], 'txt');
+          });
+        });
+      }
+
+      /**
+       * Update event
+       * @event Browser#update
+       * @type {object}
+       * @property {string} networkInterface - name of network interface
+       * @property {number} interfaceIndex
+       */
+      debug('isNew', isNew);
+      if (isNew && data) {
+        this.emit('update', data);
+      }
+    }
+  }
+
+  stop () {
+    this.networking.removeUsage(this);
+    this.networking.removeListener('packets', this.onMessageListener);
+    this.connections = {};
+  }
+
+  discover () {
+    const packet = new DNSPacket();
     packet.question.push(new DNSRecord(
-      serviceType.toString() + '.local',
+      this.serviceType.toString() + '.local',
       DNSRecord.Type.PTR, 1)
     );
-    networking.send(packet);
-  };
+    this.networking.send(packet);
+  }
+}
 
-};//--Browser constructor
-
-util.inherits(Browser, EventEmitter);
-
+module.exports = Browser


### PR DESCRIPTION
If you would start 2 browsers at the same time, only 1 would receive updates, since the services are saved on connection level. Since there's a check to only send info about new services, only the first browser would get the update. This fixes this, by saving the service information on browser level.

While add it, I took the time to modernize the browser.js file to.